### PR TITLE
GH-1: Fix RateLimit error handling

### DIFF
--- a/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterstreamSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterstreamSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.cloud.stream.app.twitterstream.source;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.stream.annotation.Bindings;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.app.twitter.TwitterCredentials;
 import org.springframework.cloud.stream.messaging.Source;
@@ -44,7 +43,6 @@ public class TwitterstreamSourceConfiguration {
 	TwitterStreamProperties twitterStreamProperties;
 
 	@Autowired
-	@Bindings(TwitterstreamSourceConfiguration.class)
 	Source source;
 
 	@Bean


### PR DESCRIPTION
Fixes spring-cloud-stream-app-starters/twitter#1

According Twitter Reconnection recommendations (https://dev.twitter.com/streaming/overview/connecting#Reconnecting) the Rate Limit error is exactly `420`